### PR TITLE
Change TaxYear visibility to public

### DIFF
--- a/src/commonMain/kotlin/uk/gov/hmrc/calculator/utils/TaxYear.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/calculator/utils/TaxYear.kt
@@ -17,7 +17,7 @@ package uk.gov.hmrc.calculator.utils
 
 import com.soywiz.klock.DateTime
 
-internal class TaxYear {
+class TaxYear {
     fun currentTaxYear() = DateTime.nowLocal().let {
         if (it < firstDayOfTaxYear(it.yearInt)) it.yearInt - 1 else it.yearInt
     }


### PR DESCRIPTION
Exposed TaxYear so we don't need to duplicate `currentTaxYear` logic in the app.