### PR TITLE
HMA-3006 fix for InvalidMutabilityException

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://app.bitrise.io/app/cd7fb52c258b9273/status.svg?token=lntO8o4xz5AUEvLwVzbo3A&branch=master)](https://app.bitrise.io/app/cd7fb52c258b9273)
 ![LINE](https://img.shields.io/badge/line--coverage-98%25-brightgreen.svg)
 ![BRANCH](https://img.shields.io/badge/branch--coverage-93%25-brightgreen.svg)
-![COMPLEXITY](https://img.shields.io/badge/complexity-1.51-brightgreen.svg)
+![COMPLEXITY](https://img.shields.io/badge/complexity-1.52-brightgreen.svg)
 [ ![Download](https://api.bintray.com/packages/hmrc/mobile-releases/tax-kalculator/images/download.svg) ](https://bintray.com/hmrc/mobile-releases/tax-kalculator/_latestVersion)
 
 ## Calculate take-home pay

--- a/src/commonTest/kotlin/uk/gov/hmrc/calculator/CalculatorTests.kt
+++ b/src/commonTest/kotlin/uk/gov/hmrc/calculator/CalculatorTests.kt
@@ -15,9 +15,9 @@
  */
 package uk.gov.hmrc.calculator
 
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import uk.gov.hmrc.calculator.exception.InvalidHoursException
 import uk.gov.hmrc.calculator.exception.InvalidWagesException
 import uk.gov.hmrc.calculator.model.PayPeriod
@@ -27,35 +27,35 @@ internal class CalculatorTests {
     @Test
     fun `GIVEN hours is zero and pay period hour WHEN calculate THEN exception`() {
         assertFailsWith<InvalidHoursException> {
-            Calculator("1250L", 20.0, payPeriod = PayPeriod.HOURLY, howManyAWeek = 0.0).run()
+            Calculator(taxCode = "1250L", wages = 20.0, payPeriod = PayPeriod.HOURLY, howManyAWeek = 0.0).run()
         }
     }
 
     @Test
     fun `GIVEN hours is null and pay period hour WHEN calculate THEN exception`() {
         assertFailsWith<InvalidHoursException> {
-            Calculator("1250L", 20.0, payPeriod = PayPeriod.HOURLY).run()
+            Calculator(taxCode = "1250L", wages = 20.0, payPeriod = PayPeriod.HOURLY).run()
         }
     }
 
     @Test
     fun `GIVEN wages is below zero WHEN calculate THEN exception`() {
         assertFailsWith<InvalidWagesException> {
-            Calculator("1250L", -190.0, payPeriod = PayPeriod.WEEKLY).run()
+            Calculator(taxCode = "1250L", wages = -190.0, payPeriod = PayPeriod.WEEKLY).run()
         }
     }
 
     @Test
     fun `GIVEN wages is zero WHEN calculate THEN exception`() {
         assertFailsWith<InvalidWagesException> {
-            Calculator("1250L", 0.0, payPeriod = PayPeriod.YEARLY).run()
+            Calculator(taxCode = "1250L", wages = 0.0, payPeriod = PayPeriod.YEARLY).run()
         }
     }
 
     @Test
     fun `GIVEN wages too high WHEN calculate THEN exception`() {
         assertFailsWith<InvalidWagesException> {
-            Calculator("1250L", 10000000.0, payPeriod = PayPeriod.YEARLY).run()
+            Calculator(taxCode = "1250L", wages = 10000000.0, payPeriod = PayPeriod.YEARLY).run()
         }
     }
 

--- a/src/commonTest/kotlin/uk/gov/hmrc/calculator/model/bands/TaxBandsTests.kt
+++ b/src/commonTest/kotlin/uk/gov/hmrc/calculator/model/bands/TaxBandsTests.kt
@@ -21,11 +21,13 @@ import kotlin.test.assertFailsWith
 import uk.gov.hmrc.calculator.exception.InvalidTaxYearException
 import uk.gov.hmrc.calculator.model.Country.ENGLAND
 import uk.gov.hmrc.calculator.model.Country.SCOTLAND
+import uk.gov.hmrc.calculator.model.Country.WALES
+import uk.gov.hmrc.calculator.utils.taxcode.toTaxCode
 
 class TaxBandsTests {
 
     @Test
-    fun invalidYear() {
+    fun `GIVEN invalid year WHEN get bands THEN fail with exception`() {
         val exception = assertFailsWith<InvalidTaxYearException> {
             TaxBands.getBands(
                 2017,
@@ -36,17 +38,126 @@ class TaxBandsTests {
     }
 
     @Test
-    fun bandsForScotland2020() {
-        val taxBand = TaxBands.getBands(2020, SCOTLAND)[1]
-        assertEquals(14585.00, taxBand.upper)
-        assertEquals(12509.00, taxBand.lower)
-        assertEquals(0.19, taxBand.percentageAsDecimal)
+    fun `GIVEN invalid year WHEN get adjusted bands THEN fail with exception`() {
+        val exception = assertFailsWith<InvalidTaxYearException> {
+            TaxBands.getAdjustedBands(
+                2017,
+                "1250L".toTaxCode()
+            )
+        }
+        assertEquals(exception.message, "2017")
+    }
 
-        assertEquals(false, taxBand.inBand(12509.00))
-        assertEquals(false, taxBand.inBand(12508.00))
-        assertEquals(true, taxBand.inBand(12510.00))
-        assertEquals(true, taxBand.inBand(14585.00))
-        assertEquals(true, taxBand.inBand(14584.00))
-        assertEquals(false, taxBand.inBand(14586.00))
+    @Test
+    fun `GIVEN year is 2020 WHEN get bands for Scotland THEN bands are as expected`() {
+        val taxBands = TaxBands.getBands(2020, SCOTLAND)
+
+        assertEquals(0.0, taxBands[0].lower)
+        assertEquals(12509.00, taxBands[0].upper)
+        assertEquals(0.0, taxBands[0].percentageAsDecimal)
+
+        assertEquals(12509.00, taxBands[1].lower)
+        assertEquals(14585.00, taxBands[1].upper)
+        assertEquals(0.19, taxBands[1].percentageAsDecimal)
+
+        assertEquals(14585.00, taxBands[2].lower)
+        assertEquals(25158.00, taxBands[2].upper)
+        assertEquals(0.20, taxBands[2].percentageAsDecimal)
+
+        assertEquals(25158.00, taxBands[3].lower)
+        assertEquals(43430.00, taxBands[3].upper)
+        assertEquals(0.21, taxBands[3].percentageAsDecimal)
+
+        assertEquals(43430.00, taxBands[4].lower)
+        assertEquals(150000.00, taxBands[4].upper)
+        assertEquals(0.41, taxBands[4].percentageAsDecimal)
+
+        assertEquals(150000.00, taxBands[5].lower)
+        assertEquals(-1.0, taxBands[5].upper)
+        assertEquals(0.46, taxBands[5].percentageAsDecimal)
+    }
+
+    @Test
+    fun `GIVEN year is 2020 WHEN get bands for ENGLAND THEN bands are as expected`() {
+        val taxBands = TaxBands.getBands(2020, ENGLAND)
+
+        assertEquals(0.0, taxBands[0].lower)
+        assertEquals(12509.00, taxBands[0].upper)
+        assertEquals(0.0, taxBands[0].percentageAsDecimal)
+
+        assertEquals(12509.00, taxBands[1].lower)
+        assertEquals(50000.0, taxBands[1].upper)
+        assertEquals(0.2, taxBands[1].percentageAsDecimal)
+
+        assertEquals(50000.0, taxBands[2].lower)
+        assertEquals(150000.0, taxBands[2].upper)
+        assertEquals(0.4, taxBands[2].percentageAsDecimal)
+
+        assertEquals(150000.0, taxBands[3].lower)
+        assertEquals(-1.0, taxBands[3].upper)
+        assertEquals(0.45, taxBands[3].percentageAsDecimal)
+    }
+
+    @Test
+    fun `GIVEN year is 2020 WHEN get bands for WALES THEN bands are as expected`() {
+        val taxBands = TaxBands.getBands(2020, WALES)
+
+        assertEquals(0.0, taxBands[0].lower)
+        assertEquals(12509.00, taxBands[0].upper)
+        assertEquals(0.0, taxBands[0].percentageAsDecimal)
+
+        assertEquals(12509.00, taxBands[1].lower)
+        assertEquals(50000.0, taxBands[1].upper)
+        assertEquals(0.2, taxBands[1].percentageAsDecimal)
+
+        assertEquals(50000.0, taxBands[2].lower)
+        assertEquals(150000.0, taxBands[2].upper)
+        assertEquals(0.4, taxBands[2].percentageAsDecimal)
+
+        assertEquals(150000.0, taxBands[3].lower)
+        assertEquals(-1.0, taxBands[3].upper)
+        assertEquals(0.45, taxBands[3].percentageAsDecimal)
+    }
+
+    @Test
+    fun `GIVEN year is 2020 WHEN get adjusted bands for 1250L THEN bands are as expected`() {
+        val taxBands = TaxBands.getAdjustedBands(2020, "1250L".toTaxCode())
+
+        assertEquals(0.0, taxBands[0].lower)
+        assertEquals(12509.00, taxBands[0].upper)
+        assertEquals(0.0, taxBands[0].percentageAsDecimal)
+
+        assertEquals(12509.00, taxBands[1].lower)
+        assertEquals(50000.0, taxBands[1].upper)
+        assertEquals(0.2, taxBands[1].percentageAsDecimal)
+
+        assertEquals(50000.0, taxBands[2].lower)
+        assertEquals(150000.0, taxBands[2].upper)
+        assertEquals(0.4, taxBands[2].percentageAsDecimal)
+
+        assertEquals(150000.0, taxBands[3].lower)
+        assertEquals(-1.0, taxBands[3].upper)
+        assertEquals(0.45, taxBands[3].percentageAsDecimal)
+    }
+
+    @Test
+    fun `GIVEN year is 2020 WHEN get adjusted bands for BR THEN bands are as expected`() {
+        val taxBands = TaxBands.getAdjustedBands(2020, "BR".toTaxCode())
+
+        assertEquals(0.0, taxBands[0].lower)
+        assertEquals(0.0, taxBands[0].upper)
+        assertEquals(0.0, taxBands[0].percentageAsDecimal)
+
+        assertEquals(0.0, taxBands[1].lower)
+        assertEquals(37491.0, taxBands[1].upper)
+        assertEquals(0.2, taxBands[1].percentageAsDecimal)
+
+        assertEquals(37491.0, taxBands[2].lower)
+        assertEquals(137491.0, taxBands[2].upper)
+        assertEquals(0.4, taxBands[2].percentageAsDecimal)
+
+        assertEquals(137491.0, taxBands[3].lower)
+        assertEquals(-1.0, taxBands[3].upper)
+        assertEquals(0.45, taxBands[3].percentageAsDecimal)
     }
 }


### PR DESCRIPTION
Fixes a mutability issue introduced in https://github.com/hmrc/tax-kalculator/pull/41/files#diff-10bad2a339c8e495921bdab3e7e9d2db.

Global vars are immutable in Kotlin Native so this resulted in crashes on iOS where we were mutating the bands in `Calculator.kt`.

https://github.com/JetBrains/kotlin-native/blob/master/IMMUTABILITY.md