### PR TITLE
Update klockVersion to minimum version avaliable on maven central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,7 @@ kotlin {
     }
 
     sourceSets {
-        val klockVersion = "2.0.1"
+        val klockVersion = "2.0.7"
         val commonMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-common"))


### PR DESCRIPTION
Running an application which depends on `uk.gov.hmrc:tax-kalculator-jvm:2.6.0` currently fails due to a dependency on an outdated version of klock which is not available on Maven Central:
```
repositories {
    // Use Maven Central for resolving dependencies.
    //mavenLocal()
    mavenCentral()
    maven {
        url = "https://maven.pkg.github.com/hmrc/tax-kalculator"
        credentials {
            username = System.getenv("GITHUB_USER_NAME")
            password = System.getenv("GITHUB_TOKEN")
        }
    }
}

dependencies {

    ...

    implementation "uk.gov.hmrc:tax-kalculator-jvm:2.6.0"

    ...

}
```

```
GITHUB_USER_NAME=mans0954 GITHUB_TOKEN=******** ./gradlew run

> Task :app:run FAILED
Execution optimizations have been disabled for task ':app:run' to ensure correctness due to the following reasons:
  - Type 'org.gradle.api.tasks.JavaExec' property 'classpath' cannot be resolved:  Could not resolve all files for configuration ':app:runtimeClasspath'. Reason: An input file collection couldn't be resolved, making it impossible to determine task inputs. Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#unresolvable_input for more details about this problem.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:run'.
> Could not resolve all files for configuration ':app:runtimeClasspath'.
   > Could not find com.soywiz.korlibs.klock:klock:2.0.1.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/soywiz/korlibs/klock/klock/2.0.1/klock-2.0.1.pom
       - https://maven.pkg.github.com/hmrc/tax-kalculator/com/soywiz/korlibs/klock/klock/2.0.1/klock-2.0.1.pom
     Required by:
         project :app > uk.gov.hmrc:tax-kalculator-jvm:2.6.0

...

BUILD FAILED in 1s
2 actionable tasks: 2 executed

```

This PR updates `klockVersion` from `2.0.1` to `2.0.7`, the closest available version on Maven Central.