### PR TITLE
HMA-9215 fixed Double.shouldApplyDefaultTaxCode() extension function to compare with default tax code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Fixed default tax code comparison when Tapering not applied and yearly income above 100k.
 
 ## [2.14.1] - 2024-10-15Z
 - Updated README to fix incorrect information.

--- a/src/commonMain/kotlin/uk/gov/hmrc/calculator/Calculator.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/calculator/Calculator.kt
@@ -151,7 +151,7 @@ class Calculator @JvmOverloads constructor(
                     yearlyWageAfterPension.getTaperingAmount(taxCodeType.taxFreeAmount)
                 )
             }
-            yearlyWageAfterPension.shouldApplyDefaultTaxCode(taxCodeType, userSuppliedTaxCode) -> {
+            yearlyWageAfterPension.shouldApplyDefaultTaxCode(taxCode = taxCode, userSuppliedTaxCode) -> {
                 listOfClarification.add(Clarification.INCOME_OVER_100K)
                 Pair(taxCodeType.getTrueTaxFreeAmount(), null)
             }

--- a/src/commonMain/kotlin/uk/gov/hmrc/calculator/Calculator.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/calculator/Calculator.kt
@@ -143,7 +143,7 @@ class Calculator @JvmOverloads constructor(
 
     private fun getTaxFreeAndTaperingAmount(yearlyWageAfterPension: Double): Pair<Double, Double?> {
         return when {
-            yearlyWageAfterPension.shouldApplyStandardTapering(taxCodeType, userSuppliedTaxCode) -> {
+            yearlyWageAfterPension.shouldApplyStandardTapering(taxCode = taxCode, userSuppliedTaxCode) -> {
                 listOfClarification.add(Clarification.INCOME_OVER_100K_WITH_TAPERING)
                 Pair(
                     taxCodeType.getTrueTaxFreeAmount().deductTapering(yearlyWageAfterPension),

--- a/src/commonMain/kotlin/uk/gov/hmrc/calculator/utils/tapering/TaperingExtensions.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/calculator/utils/tapering/TaperingExtensions.kt
@@ -44,13 +44,11 @@ internal fun Double.shouldApplyStandardTapering(taxCodeType: TaxCode, userSuppli
 
 @JvmSynthetic
 internal fun Double.shouldApplyDefaultTaxCode(taxCode: String, userSuppliedTaxCode: Boolean) =
-    isDefaultTaxCodeAndAboveHundredThousand(taxCode, this) && userSuppliedTaxCode
+    taxCode.endsWith(TaxCode.getDefaultTaxCode(), ignoreCase = true) &&
+        this.yearlyWageIsAboveHundredThousand() &&
+        userSuppliedTaxCode
 
 private fun isStandardTaxCodeAndAboveHundredThousand(taxCodeType: TaxCode, yearlyWageAfterPension: Double) =
     taxCodeType is StandardTaxCode && yearlyWageAfterPension.yearlyWageIsAboveHundredThousand()
-
-private fun isDefaultTaxCodeAndAboveHundredThousand(taxCode: String, yearlyWageAfterPension: Double) =
-    taxCode.equals(TaxCode.getDefaultTaxCode(), ignoreCase = true) &&
-        yearlyWageAfterPension.yearlyWageIsAboveHundredThousand()
 
 private const val TAPERING_THRESHOLD = 100000.0

--- a/src/commonMain/kotlin/uk/gov/hmrc/calculator/utils/tapering/TaperingExtensions.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/calculator/utils/tapering/TaperingExtensions.kt
@@ -50,6 +50,7 @@ private fun isStandardTaxCodeAndAboveHundredThousand(taxCodeType: TaxCode, yearl
     taxCodeType is StandardTaxCode && yearlyWageAfterPension.yearlyWageIsAboveHundredThousand()
 
 private fun isDefaultTaxCodeAndAboveHundredThousand(taxCode: String, yearlyWageAfterPension: Double) =
-    taxCode.equals(TaxCode.getDefaultTaxCode(), ignoreCase = true) && yearlyWageAfterPension.yearlyWageIsAboveHundredThousand()
+    taxCode.equals(TaxCode.getDefaultTaxCode(), ignoreCase = true) &&
+        yearlyWageAfterPension.yearlyWageIsAboveHundredThousand()
 
 private const val TAPERING_THRESHOLD = 100000.0

--- a/src/commonMain/kotlin/uk/gov/hmrc/calculator/utils/tapering/TaperingExtensions.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/calculator/utils/tapering/TaperingExtensions.kt
@@ -43,10 +43,13 @@ internal fun Double.shouldApplyStandardTapering(taxCodeType: TaxCode, userSuppli
     isStandardTaxCodeAndAboveHundredThousand(taxCodeType, this) && !userSuppliedTaxCode
 
 @JvmSynthetic
-internal fun Double.shouldApplyDefaultTaxCode(taxCodeType: TaxCode, userSuppliedTaxCode: Boolean) =
-    isStandardTaxCodeAndAboveHundredThousand(taxCodeType, this) && userSuppliedTaxCode
+internal fun Double.shouldApplyDefaultTaxCode(taxCode: String, userSuppliedTaxCode: Boolean) =
+    isDefaultTaxCodeAndAboveHundredThousand(taxCode, this) && userSuppliedTaxCode
 
 private fun isStandardTaxCodeAndAboveHundredThousand(taxCodeType: TaxCode, yearlyWageAfterPension: Double) =
     taxCodeType is StandardTaxCode && yearlyWageAfterPension.yearlyWageIsAboveHundredThousand()
+
+private fun isDefaultTaxCodeAndAboveHundredThousand(taxCode: String, yearlyWageAfterPension: Double) =
+    taxCode.equals(TaxCode.getDefaultTaxCode(), ignoreCase = true) && yearlyWageAfterPension.yearlyWageIsAboveHundredThousand()
 
 private const val TAPERING_THRESHOLD = 100000.0

--- a/src/commonMain/kotlin/uk/gov/hmrc/calculator/utils/tapering/TaperingExtensions.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/calculator/utils/tapering/TaperingExtensions.kt
@@ -15,7 +15,6 @@
  */
 package uk.gov.hmrc.calculator.utils.tapering
 
-import uk.gov.hmrc.calculator.model.taxcodes.StandardTaxCode
 import uk.gov.hmrc.calculator.model.taxcodes.TaxCode
 import kotlin.jvm.JvmSynthetic
 
@@ -39,16 +38,15 @@ internal fun Double.getTaperingAmount(maximumTaperingAmount: Double): Double {
 internal fun Double.yearlyWageIsAboveHundredThousand() = this > TAPERING_THRESHOLD
 
 @JvmSynthetic
-internal fun Double.shouldApplyStandardTapering(taxCodeType: TaxCode, userSuppliedTaxCode: Boolean) =
-    isStandardTaxCodeAndAboveHundredThousand(taxCodeType, this) && !userSuppliedTaxCode
+internal fun Double.shouldApplyStandardTapering(taxCode: String, userSuppliedTaxCode: Boolean) =
+    isDefaultTaxCodeAndAboveHundredThousand(taxCode, this) && !userSuppliedTaxCode
 
 @JvmSynthetic
 internal fun Double.shouldApplyDefaultTaxCode(taxCode: String, userSuppliedTaxCode: Boolean) =
-    taxCode.endsWith(TaxCode.getDefaultTaxCode(), ignoreCase = true) &&
-        this.yearlyWageIsAboveHundredThousand() &&
-        userSuppliedTaxCode
+    isDefaultTaxCodeAndAboveHundredThousand(taxCode, this) && userSuppliedTaxCode
 
-private fun isStandardTaxCodeAndAboveHundredThousand(taxCodeType: TaxCode, yearlyWageAfterPension: Double) =
-    taxCodeType is StandardTaxCode && yearlyWageAfterPension.yearlyWageIsAboveHundredThousand()
+private fun isDefaultTaxCodeAndAboveHundredThousand(taxCode: String, yearlyWageAfterPension: Double) =
+    taxCode.endsWith(TaxCode.getDefaultTaxCode(), ignoreCase = true) &&
+        yearlyWageAfterPension.yearlyWageIsAboveHundredThousand()
 
 private const val TAPERING_THRESHOLD = 100000.0

--- a/src/commonTest/kotlin/uk/gov/hmrc/calculator/CalculatorTests.kt
+++ b/src/commonTest/kotlin/uk/gov/hmrc/calculator/CalculatorTests.kt
@@ -1695,9 +1695,23 @@ internal class CalculatorTests {
     }
 
     @Test
-    fun `GIVEN tapering not apply AND wage is over 100k AND correct tax code applied WHEN calculate THEN clarification does not contain 100K clarification`() {
+    fun `GIVEN tapering not apply AND wage is over 100k AND correct tax code non-standard applied WHEN calculate THEN clarification does not contain 100K clarification`() {
         val result = Calculator(
             taxCode = "0T",
+            userSuppliedTaxCode = true,
+            wages = 125140.0,
+            payPeriod = PayPeriod.YEARLY,
+            taxYear = TaxYear.TWENTY_TWENTY_THREE,
+        ).run()
+
+        assertFalse(result.listOfClarification.contains(Clarification.INCOME_OVER_100K))
+        assertFalse(result.listOfClarification.contains(Clarification.INCOME_OVER_100K_WITH_TAPERING))
+    }
+
+    @Test
+    fun `GIVEN tapering not apply AND wage is over 100k AND non-default standard tax code applied WHEN calculate THEN clarification does not contain 100K clarification`() {
+        val result = Calculator(
+            taxCode = "1100L",
             userSuppliedTaxCode = true,
             wages = 125140.0,
             payPeriod = PayPeriod.YEARLY,


### PR DESCRIPTION
ticket :- https://jira.tools.tax.service.gov.uk/browse/HMA-9215

Fixed the Double.shouldApplyDefaultTaxCode(): - change the condition from the standardTaxCode to default-tax-code
<img width="292" alt="Screenshot 2024-10-30 at 09 52 45" src="https://github.com/user-attachments/assets/b803ca39-2cd8-4499-b2ef-fa1f7e536ead">
